### PR TITLE
Update to the minecraft 1.20 and fix the missing user issue

### DIFF
--- a/linux-java.Dockerfile
+++ b/linux-java.Dockerfile
@@ -1,10 +1,14 @@
 # escape=`
 FROM lacledeslan/steamcmd:linux as DOWNLOADER
 
-RUN curl -sSL "https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar" -o /output/minecraft-server.jar &&`
-    echo "c9df48efed58511cdd0213c56b9013a7b5c9ac1f /output/minecraft-server.jar" | sha1sum -c -;
+RUN curl -sSL "https://piston-data.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar" -o /output/minecraft-server.jar &&`
+    echo "84194a2f286ef7c14ed7ce0090dba59902951553 /output/minecraft-server.jar" | sha1sum -c -;
 
 FROM eclipse-temurin:20-jdk as BUILDER
+
+RUN useradd --home /app --gid root --system Minecraft &&`
+    mkdir --parents /app &&`
+    chown Minecraft:root -R /app;
 
 COPY --chown=Minecraft:root --from=DOWNLOADER /output/minecraft-server.jar /output/minecraft-server.jar
 


### PR DESCRIPTION
Pretty simple PR to update to the newest minecraft. The docker build complained about missing a minecraft user on the host server which I assume is something that was already on the system that's being used to do builds. So I added that useradd section earlier in the build and it works. 
On startup minecraft complains about missing a `server.properties` file but it seems to continue running and passing the tests. I'm a newb with minecraft so I think this is ok but double check me. 